### PR TITLE
Split out timeouts to a single getter and a stream

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ app.get('/bans', bans.get);
 app.post('/bans', bans.post);
 
 app.get('/timeouts', timeouts.get);
+app.get('/timeouts', timeouts.stream);
 app.post('/timeouts', timeouts.post);
 
 app.get('/deleted', deleted.get);

--- a/src/routes/timeouts.js
+++ b/src/routes/timeouts.js
@@ -10,6 +10,13 @@ module.exports = {
     },
 
     get: async function (req, res) {
+        try{
+            let data = await fetch.fetch(req, 'timeouts')
+            res.send(data)
+        } catch (err) { res.send(err) }
+    },
+
+    stream: async function (req, res) {
 
         res.set({
             "Content-Type": "text/event-stream",


### PR DESCRIPTION
Currently the only way to access timeouts is through a stream, Split that out into two routes